### PR TITLE
t pushSwitch cleaning tests to fixture workbooks

### DIFF
--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,20 +1,32 @@
 from src.cleaning.atlas_clean import clean_atlas
 
+# --------------------------------------------------------------------
+# Use the 1 k-row fixture workbooks that travel with the repository
+# --------------------------------------------------------------------
 ABX_FIX = "tests/fixtures/atlas_antibiotics_fixture.xlsx"
 AFG_FIX = "tests/fixtures/atlas_antifungals_fixture.xlsx"
 
+
 def test_clean_has_required_columns():
-    df_long = clean_atlas("data/raw/ATLAS_Antibiotics/2025_03_11 atlas_antibiotics.xlsx")
-    assert {"drug", "mic_value", "sir_flag", "resistant"}.issubset(df_long.columns)
+    """
+    The cleaned antibiotics fixture must include the core long-format columns.
+    """
+    df_long = clean_atlas(ABX_FIX)
+    required = {"drug", "mic_value", "sir_flag", "resistant"}
+    assert required.issubset(df_long.columns)
+
 
 def test_country_not_null():
-    df_long = clean_atlas("data/raw/ATLAS_Antifungals/vivli_sentry_2010_2023.xlsx")
+    """
+    No row in the antifungals fixture should have a null country after cleaning.
+    """
+    df_long = clean_atlas(AFG_FIX)
     assert df_long["country"].notna().all()
+
 
 def test_resistant_not_all_nan():
     """
-    At least one row in the cleaned antibiotics data
-    must have a non-NaN 'resistant' value.
+    At least one row in the antibiotics fixture must have a non-NaN 'resistant'.
     """
-    df_long = clean_atlas("data/raw/ATLAS_Antibiotics/2025_03_11 atlas_antibiotics.xlsx")
-    assert df_long["resistant"].notna().any(), "All resistant values are NaN!"
+    df_long = clean_atlas(ABX_FIX)
+    assert df_long["resistant"].notna().any()


### PR DESCRIPTION
Switch cleaning tests to fixture workbooks

* All tests now load 1 k-row fixture XLSX files
* CI no longer depends on raw data